### PR TITLE
Fix FAQ - cli link

### DIFF
--- a/src/faq.js
+++ b/src/faq.js
@@ -87,7 +87,7 @@ export default [
     faq_answer:
       'We offer two options for uploading data onto OpenNeuro. ' +
       'The first is to upload via the web interface. ' +
-      'The second is to upload via our [command-line utility tool](cli.openneuro.org)',
+      'The second is to upload via our [command-line utility tool](https://docs.openneuro.org/packages-openneuro-cli-readme)',
   },
   {
     faq:


### PR DESCRIPTION
PR resolves our cli link redirection. the previous link redirected within the OpenNeuro space rather than directing to our cli documentation. 